### PR TITLE
Email notifications for submission, clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+config.env
+node_modules
+/.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "TeamUp",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,2 +1,0 @@
-config.env
-node_modules

--- a/server/app.js
+++ b/server/app.js
@@ -1,17 +1,10 @@
 // app.js
 
-
+require('dotenv').config({ path: './config.env' });
 const express = require('express');
 const connectDB = require('./config/db');
-require('dotenv').config({ path: './config.env' });
-
-
-
 
 const app = express();
-
-
-
 const cors = require('cors');
 const corsOptions = {
     origin: 'http://localhost:3000',
@@ -19,10 +12,6 @@ const corsOptions = {
     optionSuccessStatus: 200
 }
 app.use(cors(corsOptions));
-
-
-
-
 
 const team_routes = require('./routes/api/teams');
 const project_routes = require('./routes/api/projects');
@@ -37,12 +26,7 @@ app.use('/api/login', login_route)
 app.use('/api/users', user_routes);
 app.use('api/teams/team_submit', team_submit_routes);
 
-
 // Connect Database
 connectDB();
-
-app.get('/', (req, res) => res.send('Hello world!'));
-
 const port = process.env.PORT || 8082;
-
 app.listen(port, () => console.log(`Server running on port ${port}`));

--- a/server/config/db.js
+++ b/server/config/db.js
@@ -1,9 +1,8 @@
 
 // db.js
-  
+
 const mongoose = require('mongoose');
-const config = require('config');
-const db = config.get('mongoURI');
+const db = process.env.ATLAS_URI;
 
 const connectDB = async () => {
   try {

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -1,3 +1,0 @@
-{
-    "mongoURI":"mongodb+srv://Cluster13473:teamup@cluster13473.ziewtw1.mongodb.net/test?retryWrites=true&w=majority"
-}

--- a/server/config/email.js
+++ b/server/config/email.js
@@ -1,0 +1,38 @@
+const nodemailer = require('nodemailer');
+
+// Sends an email with a created message to a specific user
+//
+// @param {String} to The email to send the message to
+// @param {String} message The content of the email
+// @return {promise}
+function sendEmail(to, message) {
+    return new Promise((resolve, reject) => {
+        // transporter to send mail
+        let transporter = nodemailer.createTransport({
+            service: 'gmail',
+            auth: {
+                user: process.env.GMAIL_USER,
+                pass: process.env.GMAIL_PASS
+            }
+        });
+
+        // specified mail options
+        let mailOptions = {
+            from: process.env.GMAIL_USER,
+            to: to,
+            subject: "<No Reply> Confirmation of Capstone Project Selections",
+            text: message
+        };
+
+        // send the mail using the specified mail options and transporter
+        transporter.sendMail(mailOptions, function (error, info) {
+            if (error) {
+                reject(error);
+            } else {
+                console.log(info.response);
+                resolve();
+            }
+        });
+    });
+}
+module.exports = sendEmail;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,6 +23,7 @@
         "jsonwebtoken": "^9.0.0",
         "mongoose": "^6.10.0",
         "mongoose-unique-validator": "^3.1.0",
+        "nodemailer": "^6.9.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "validation": "0.0.1"
@@ -4547,6 +4548,14 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.1.tgz",
+      "integrity": "sha512-qHw7dOiU5UKNnQpXktdgQ1d3OFgRAekuvbJLcdG5dnEo/GtcTHRYM7+UfJARdOFU9WUQO8OiIamgWPmiSFHYAA==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -9621,6 +9630,11 @@
           }
         }
       }
+    },
+    "nodemailer": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.1.tgz",
+      "integrity": "sha512-qHw7dOiU5UKNnQpXktdgQ1d3OFgRAekuvbJLcdG5dnEo/GtcTHRYM7+UfJARdOFU9WUQO8OiIamgWPmiSFHYAA=="
     },
     "nodemon": {
       "version": "1.19.4",

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^6.10.0",
     "mongoose-unique-validator": "^3.1.0",
+    "nodemailer": "^6.9.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "validation": "0.0.1"

--- a/server/routes/api/teams.js
+++ b/server/routes/api/teams.js
@@ -1,12 +1,13 @@
 // routes/api/teams.js
 // Defines API endpoints for creating, updating, and deleting teams from the database
 
-const { Email } = require('@mui/icons-material');
+const sendEmail = require('../../config/email');
 const express = require('express');
 var app = express();
 app.use(express.json());
 
 const Team = require('../../models/Team');
+const User = require('../../models/User');
 
 // @route GET api/teams
 // @description Get all teams
@@ -26,8 +27,6 @@ app.get('/', (req, res) => {
       .then(teams => res.json(teams))
       .catch(err => res.status(404).json({ noteamsfound: err }));
   }
-
-
 
   // Otherwise, return all teams
   else {
@@ -80,10 +79,21 @@ app.put('/team_submit/:id', async (req, res) => {
         is_finalized: 'true'
       }
     }, { new: true });
-    res.send("Congratulations! You submitted your team!");
-  }
-  catch {
-    res.status(404)
+
+    // send email confirmation for all members on the team
+    for (let i = 0; i < updatedTeam.members.length; i++) {
+      const member = await User.findById(updatedTeam.members[i]);
+      try {
+        await sendEmail(member.email, "this is a test from capstone - this will be a doc");
+      } catch (error) {
+        console.error(`Error sending email to ${member.email}: ${error}`);
+        res.status(404).json(`Error sending email to ${member.email}: ${error}`);
+        return;
+      }
+    }
+    res.send("Congratulations, you submitted your team! All members should have received an email confirming the project preferences");
+  } catch (error) {
+    res.status(404).json(error)
   }
 });
 


### PR DESCRIPTION
# Change 1: Email
Tested by sending emails to a team I created, also ensured errors would be passed all the way back to the response:
Test
<img width="858" alt="image" src="https://user-images.githubusercontent.com/55103880/225214932-005b4008-7f14-4a77-a343-a87b6fc2fc42.png">
Resulting Email
<img width="907" alt="Screenshot 2023-03-15 at 12 23 24 AM" src="https://user-images.githubusercontent.com/55103880/225215056-8a729e3b-61d2-4487-9d1c-bd835f34dd1e.png">

Currently it just sends text, but once Swarita create that document the `sendEmail` `message` parameter can be changed when called
# Change 2: Clean Up
Im not sure why, but our atlas URI was visible in our github, so i moved it back to the config.env file. I also removed a bunch of whitespace



