### PR TITLE
Added PUT request for joining a public team as an authenticated user

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -63,6 +63,10 @@ const UserSchema = new mongoose.Schema({
   token: {
     type: String,
   },
+  team: {
+    type: ObjectId,
+    required: false,
+  }
 });
 UserSchema.plugin(uniqueValidator, { message: "Email Already Exists." });
 module.exports = User = mongoose.model("User", UserSchema);

--- a/server/routes/api/teams.js
+++ b/server/routes/api/teams.js
@@ -192,6 +192,7 @@ app.put('/join/:id', auth, (req, res) => {
             })
         } else {
           console.log("TODO: implement logic for private teams - see issue #17 in GitHub")
+          res.status(400).json({ error: "Private team logic not yet implemented" })
         }
       }
     })

--- a/server/routes/api/teams.js
+++ b/server/routes/api/teams.js
@@ -7,6 +7,9 @@ var app = express();
 app.use(express.json());
 
 const Team = require('../../models/Team');
+const User = require('../../models/User');
+
+const auth = require("./middleware/auth")
 
 // @route GET api/teams
 // @description Get all teams
@@ -105,6 +108,76 @@ app.delete('/:id', (req, res) => {
   Team.findByIdAndRemove(req.params.id, req.body)
     .then(team => res.json({ mgs: 'Team ' + team.id + ' deleted successfully' }))
     .catch(err => res.status(404).json({ error: err }));
+});
+
+
+// @route PUT api/teams/join/:id
+// @description Allows an authenticated user to join a public/private team
+// @access Private
+// @param ObjectId user_id
+app.put('/join/:id', auth, (req, res) => {
+  Team.findById(req.params.id)
+    .then(team => {
+
+      // do not allow anyone to join a finalized team
+      if (team.is_finalized) {
+        res.status(400).json({ error: 'Team ' + team.id + ' is already finalized and cannot be modified' })
+      } else {
+
+        if (team.is_public) {
+
+          // prevent duplicates of the same user in a team
+          if (!team.members.includes(req.body.user_id)) {
+            team.members.push(req.body.user_id)
+          }
+
+          team.save()
+            .then(team => console.log('User ' + req.body.user_id + ' successfully joined team ' + team.id));
+
+        } else {
+          console.log("TODO: implement logic for private teams - see issue #17 in GitHub")
+        }
+
+        // now, update the user to contain the team ID they are a part of
+        User.findById(req.body.user_id)
+          .then(user => {
+
+            // if the user is already on a team, remove them from that team
+            if (user.team && user.team != team.id) {
+              Team.findById(user.team)
+                .then(old_team => {
+
+                  // remove user from their old team
+                  team_without_user = []
+                  for (let i = 0; i < old_team.members.length; i++) {
+                    if (old_team.members[i] != req.body.user_id) {
+                      team_without_user.push(old_team.members[i])
+                    }
+                  }
+
+                  old_team.members = team_without_user
+
+                  // if this user was the only member on that team, delete the old team completely
+                  if (team_without_user.length == 0) {
+                    old_team.delete()
+                      .then(old_team => console.log("Deleted team " + old_team.id))
+                  } else {
+                    old_team.save()
+                      .then(old_team => console.log("Removed user " + req.body.user_id + " from team " + old_team.id))
+                  }
+                })
+            }
+
+            // add user to their new team
+            user.team = team.id
+            user.save()
+              .then(user => console.log("Updated user " + user.id + " to store team ID " + team.id))
+          })
+
+        res.json({ mgs: 'User ' + req.body.user_id + ' successfully joined team ' + team.id })
+      }
+    })
+    .catch(err => res.status(404).json({ noteamfound: err }));
 });
 
 module.exports = app;

--- a/server/routes/api/teams.js
+++ b/server/routes/api/teams.js
@@ -130,10 +130,6 @@ app.put('/join/:id', auth, (req, res) => {
           if (!team.members.includes(req.body.user_id)) {
             team.members.push(req.body.user_id)
           }
-
-          team.save()
-            .then(team => console.log('User ' + req.body.user_id + ' successfully joined team ' + team.id));
-
         } else {
           console.log("TODO: implement logic for private teams - see issue #17 in GitHub")
         }
@@ -147,37 +143,50 @@ app.put('/join/:id', auth, (req, res) => {
               Team.findById(user.team)
                 .then(old_team => {
 
-                  // remove user from their old team
-                  team_without_user = []
-                  for (let i = 0; i < old_team.members.length; i++) {
-                    if (old_team.members[i] != req.body.user_id) {
-                      team_without_user.push(old_team.members[i])
-                    }
-                  }
-
-                  old_team.members = team_without_user
-
-                  // if this user was the only member on that team, delete the old team completely
-                  if (team_without_user.length == 0) {
-                    old_team.delete()
-                      .then(old_team => console.log("Deleted team " + old_team.id))
+                  // if the user is on a finalized team already, do not allow them to join a new team
+                  if (old_team.is_finalized) {
+                    res.status(400).json({ mgs: 'User ' + user.id + ' is already on a finalized team and cannot join a new one' })
                   } else {
-                    old_team.save()
-                      .then(old_team => console.log("Removed user " + req.body.user_id + " from team " + old_team.id))
+
+                    // remove user from their old team
+                    team_without_user = []
+                    for (let i = 0; i < old_team.members.length; i++) {
+                      if (old_team.members[i] != req.body.user_id) {
+                        team_without_user.push(old_team.members[i])
+                      }
+                    }
+
+                    old_team.members = team_without_user
+
+                    // if this user was the only member on that team, delete the old team completely
+                    if (team_without_user.length == 0) {
+                      old_team.delete()
+                        .then(old_team => console.log("Deleted team " + old_team.id))
+                    } else {
+                      old_team.save()
+                        .then(old_team => console.log("Removed user " + req.body.user_id + " from team " + old_team.id))
+                    }
+
+                    // add user to their new team
+                    user.team = team.id
+                    user.save()
+                      .then(user => console.log("Updated user " + user.id + " to store team ID " + team.id))
+                    team.save();
+                    res.json({ mgs: 'User ' + req.body.user_id + ' successfully joined team ' + team.id })
                   }
                 })
+            } else {
+              // otherwise, always add the user to the new team
+              user.team = team.id
+              team.save();
+              user.save()
+                .then(user => console.log("Updated user " + user.id + " to store team ID " + team.id))
+              res.json({ mgs: 'User ' + req.body.user_id + ' successfully joined team ' + team.id })
             }
-
-            // add user to their new team
-            user.team = team.id
-            user.save()
-              .then(user => console.log("Updated user " + user.id + " to store team ID " + team.id))
           })
-
-        res.json({ mgs: 'User ' + req.body.user_id + ' successfully joined team ' + team.id })
       }
     })
-    .catch(err => res.status(404).json({ noteamfound: err }));
+    .catch(err => res.status(400).json({ error: err }));
 });
 
 module.exports = app;

--- a/server/routes/api/teams.js
+++ b/server/routes/api/teams.js
@@ -139,60 +139,60 @@ app.put('/join/:id', auth, (req, res) => {
           if (!team.members.includes(req.body.user_id)) {
             team.members.push(req.body.user_id)
           }
+
+          // now, update the user to contain the team ID they are a part of
+          User.findById(req.body.user_id)
+            .then(user => {
+
+              // if the user is already on a team, remove them from that team
+              if (user.team && user.team != team.id) {
+                Team.findById(user.team)
+                  .then(old_team => {
+
+                    // if the user is on a finalized team already, do not allow them to join a new team
+                    if (old_team.is_finalized) {
+                      res.status(400).json({ mgs: 'User ' + user.id + ' is already on a finalized team and cannot join a new one' })
+                    } else {
+
+                      // remove user from their old team
+                      team_without_user = []
+                      for (let i = 0; i < old_team.members.length; i++) {
+                        if (old_team.members[i] != req.body.user_id) {
+                          team_without_user.push(old_team.members[i])
+                        }
+                      }
+
+                      old_team.members = team_without_user
+
+                      // if this user was the only member on that team, delete the old team completely
+                      if (team_without_user.length == 0) {
+                        old_team.delete()
+                          .then(old_team => console.log("Deleted team " + old_team.id))
+                      } else {
+                        old_team.save()
+                          .then(old_team => console.log("Removed user " + req.body.user_id + " from team " + old_team.id))
+                      }
+
+                      // add user to their new team
+                      user.team = team.id
+                      user.save()
+                        .then(user => console.log("Updated user " + user.id + " to store team ID " + team.id))
+                      team.save();
+                      res.json({ mgs: 'User ' + req.body.user_id + ' successfully joined team ' + team.id })
+                    }
+                  })
+              } else {
+                // otherwise, always add the user to the new team
+                user.team = team.id
+                team.save();
+                user.save()
+                  .then(user => console.log("Updated user " + user.id + " to store team ID " + team.id))
+                res.json({ mgs: 'User ' + req.body.user_id + ' successfully joined team ' + team.id })
+              }
+            })
         } else {
           console.log("TODO: implement logic for private teams - see issue #17 in GitHub")
         }
-
-        // now, update the user to contain the team ID they are a part of
-        User.findById(req.body.user_id)
-          .then(user => {
-
-            // if the user is already on a team, remove them from that team
-            if (user.team && user.team != team.id) {
-              Team.findById(user.team)
-                .then(old_team => {
-
-                  // if the user is on a finalized team already, do not allow them to join a new team
-                  if (old_team.is_finalized) {
-                    res.status(400).json({ mgs: 'User ' + user.id + ' is already on a finalized team and cannot join a new one' })
-                  } else {
-
-                    // remove user from their old team
-                    team_without_user = []
-                    for (let i = 0; i < old_team.members.length; i++) {
-                      if (old_team.members[i] != req.body.user_id) {
-                        team_without_user.push(old_team.members[i])
-                      }
-                    }
-
-                    old_team.members = team_without_user
-
-                    // if this user was the only member on that team, delete the old team completely
-                    if (team_without_user.length == 0) {
-                      old_team.delete()
-                        .then(old_team => console.log("Deleted team " + old_team.id))
-                    } else {
-                      old_team.save()
-                        .then(old_team => console.log("Removed user " + req.body.user_id + " from team " + old_team.id))
-                    }
-
-                    // add user to their new team
-                    user.team = team.id
-                    user.save()
-                      .then(user => console.log("Updated user " + user.id + " to store team ID " + team.id))
-                    team.save();
-                    res.json({ mgs: 'User ' + req.body.user_id + ' successfully joined team ' + team.id })
-                  }
-                })
-            } else {
-              // otherwise, always add the user to the new team
-              user.team = team.id
-              team.save();
-              user.save()
-                .then(user => console.log("Updated user " + user.id + " to store team ID " + team.id))
-              res.json({ mgs: 'User ' + req.body.user_id + ' successfully joined team ' + team.id })
-            }
-          })
       }
     })
     .catch(err => res.status(400).json({ error: err }));


### PR DESCRIPTION
### This PR adds a PUT request for joining a public team.

Request URL: `/api/teams/join/<team id>`
Request Header: `x-access-token: <user auth token>`
Request Body: 
```
{
     "user_id": <user id>
}
```

-----

### Basic requirements to join a team:

- The user that is attempting to join must be logged in (if not, they see this error message)
![no token](https://user-images.githubusercontent.com/55221077/226527807-a77b6612-5849-4fc6-964c-246c6f1e1b3a.png)
- The team must not have been finalized yet (if not, they see this error message)
![finalized](https://user-images.githubusercontent.com/55221077/226527878-009ead6e-2667-4ce6-a83c-417528b024d7.png)
- The user must not be a member of another finalized team (if they are, they see this error message)
![alaredy](https://user-images.githubusercontent.com/55221077/226531715-f3062623-b0cf-491e-8e9c-3177444bb0a1.png)

-----

### Additional logic for when a user is switching from one team to another
- A user can only be part of one team at a time - if the user is already on another team, they are removed from this team (as long as the team is not finalized)

#### Example flow of a user switching between teams:

Originally, two users are on team 21:
![initial step](https://user-images.githubusercontent.com/55221077/226531857-034e2f27-033d-4c67-82fb-1e191bd1b802.png)

The user with ID ending in -7971 wants to switch to team 20, which is a public, non-finalized team:
![step 2](https://user-images.githubusercontent.com/55221077/226531966-34f1ece6-b14b-4df0-be60-a682464d2891.png)

After performing the request, the user is removed from Team 21 and added to Team 20:
![step 4](https://user-images.githubusercontent.com/55221077/226532092-80d00a5b-0d19-4496-a521-d1287d8d0ad7.png)

Now, Team 21 only has one user:
![step 6](https://user-images.githubusercontent.com/55221077/226532193-57ce71d2-d315-46a9-9476-ec8bd5bda304.png)

-----

### If all users leave a team, that team is deleted

#### Example flow of an empty team being deleted:

The last remaining member of Team 21 also moves to Team 20:
![step 10](https://user-images.githubusercontent.com/55221077/226532292-7fcf9e42-6cf5-43fd-997c-94d97c56a632.png)

Team 21 is deleted during the request:
![step 11](https://user-images.githubusercontent.com/55221077/226532330-26c7f2e5-eeee-47b8-9ae3-27f2e1d47d95.png)

Team 21 no longer appears when querying the complete list of teams:
![step 12](https://user-images.githubusercontent.com/55221077/226532379-6fbc1d70-5138-4249-9e5d-76f29a7d4a94.png)


