### PR TITLE
Added all project details to user GET

### DIFF
--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -12,7 +12,18 @@ const Project = require('../../models/Project');
 // @description Get single user's information by id
 // @access Private
 app.get('/:id', auth, async (req, res) => {
-  var user = await User.findById(req.params.id)
+
+  try {
+    var user = await User.findById(req.params.id)
+  } catch (error) {
+    res.status(404).json({ nouserfound: error })
+    return
+  }
+
+  if (!user) {
+    res.status(404).json({ nouserfound: "Please input a valid user ID" })
+    return
+  }
 
   project_ids = user.project_preferences;
 

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -6,14 +6,24 @@ var app = express();
 app.use(express.json());
 const auth = require("./middleware/auth")
 const User = require('../../models/User');
+const Project = require('../../models/Project');
 
 // @route GET api/users/:id
 // @description Get single user's information by id
 // @access Private
-app.get('/:id', auth, (req, res) => {
-  User.findById(req.params.id)
-    .then(user => res.json(user))
-    .catch(err => res.status(404).json({ nouserfound: err }));
+app.get('/:id', auth, async (req, res) => {
+  var user = await User.findById(req.params.id)
+
+  project_ids = user.project_preferences;
+
+  // include the project details in the response
+  var project_details = await Promise.all(project_ids.map(async (id) => {
+    var project = await Project.findById(id);
+    return project;
+  }))
+  user = user.toJSON()
+  user.project_details = project_details
+  res.json(user)
 });
 
 // @route PUT api/users/:id


### PR DESCRIPTION
This PR adds all of a project's attributes into the GET request for a single user. This is to improve loading time on the frontend.

Now, the GET request response includes a field called `project_details` which includes all attributes of the user's preferred projects (including the project's name).

<img width="1118" alt="Screenshot 2023-04-23 at 11 06 41 PM" src="https://user-images.githubusercontent.com/55221077/233898114-9b89fa00-5914-421e-be9c-8d6b3345869f.png">

This PR also includes error-handling:

<img width="1089" alt="Screenshot 2023-04-23 at 11 06 51 PM" src="https://user-images.githubusercontent.com/55221077/233898131-d309e198-0806-42b0-980e-4b307337322a.png">
